### PR TITLE
Add ustream.tv to list of allowed iframes

### DIFF
--- a/videoframes/init.php
+++ b/videoframes/init.php
@@ -16,7 +16,8 @@ class VideoFrames extends Plugin {
 		'www.dailymotion.com' => '/embed/video/',
 		'www.viddler.com' => '/embed/',
 		'w.soundcloud.com' => '/player/',
-		'www.facebook.com' => '/video/embed'
+		'www.facebook.com' => '/video/embed',
+		'www.ustream.tv' => '/embed/'
 	);
 
 	/**


### PR DESCRIPTION
Examples I've seen of ustream already use iframes, not an embed tag.  The "share" link(s) on ustream's site also provide just iframe code, not an embed code. (fixes #15)
